### PR TITLE
Přidána in-memory cache pro reflexe tříd entit

### DIFF
--- a/src/Entity.php
+++ b/src/Entity.php
@@ -14,6 +14,7 @@ namespace YetORM;
 use Nette;
 use Nette\Utils\Strings as NStrings;
 use Nette\Database\Table\ActiveRow as NActiveRow;
+use Nette\Reflection\ClassType as NClassType;
 
 
 abstract class Entity extends Nette\Object
@@ -21,6 +22,9 @@ abstract class Entity extends Nette\Object
 
 	/** @var NActiveRow */
 	protected $row;
+
+	/** @var array */
+	protected static $reflections = array();
 
 
 
@@ -174,6 +178,20 @@ abstract class Entity extends Nette\Object
 
 			throw $e;
 		}
+	}
+
+
+
+	/**
+	 * @return NClassType
+	 */
+	public static function getReflection()
+	{
+		$class = get_called_class();
+		if (!array_key_exists($class, static::$reflections)) {
+			static::$reflections[$class] = parent::getReflection();
+		}
+		return static::$reflections[$class];
 	}
 
 


### PR DESCRIPTION
V současné době se u entit při každém použití magické metody **__get** nebo **__set** vytváří nová reflexe entity. Jelikož je tato akce v PHP poměrně drahá, je výhodné vytvořené reflexe recyklovat (tím více, čím mají entity více položek).

Late static binding v PHP funguje pouze pro proměnné a metody v odvozené třídě nově definované (hezky je to vysvětlené například zde: http://stackoverflow.com/questions/6000385/why-doesnt-late-static-binding-work-with-variables-in-php-5-3?answertab=votes#tab-top). Proto se v implementaci udržuje na jednom místě celá kolekce získaných reflexí – nestačí jen jejich uchovávání ve static::$reflection.

Změna předpokládá, že se struktura entity nebude během životního cyklu aplikace nějakou černou magií měnit. To IMHO nevadí – nedokážu si představit, kdy by se dělání něčeho takového mohlo hodit…

Testy jsem spouštěl a prochází. :)
