### PR TITLE
Property reflections include descriptions

### DIFF
--- a/src/YetORM/Reflection/AnnotationProperty.php
+++ b/src/YetORM/Reflection/AnnotationProperty.php
@@ -32,9 +32,9 @@ class AnnotationProperty extends EntityProperty
 	 * @param  string $column
 	 * @param  bool $nullable
 	 */
-	function __construct($reflection, $name, $readonly, $type, $column, $nullable)
+	function __construct($reflection, $name, $readonly, $type, $description, $column, $nullable)
 	{
-		parent::__construct($reflection, $name, $readonly, $type);
+		parent::__construct($reflection, $name, $readonly, $type, $description);
 
 		$this->column = (string) $column;
 		$this->nullable = (bool) $nullable;

--- a/src/YetORM/Reflection/EntityProperty.php
+++ b/src/YetORM/Reflection/EntityProperty.php
@@ -30,6 +30,9 @@ abstract class EntityProperty extends Nette\Object
 	/** @var string */
 	private $type;
 
+	/** @var string */
+	private $description;
+
 
 	/**
 	 * @param  EntityType $reflection
@@ -37,12 +40,13 @@ abstract class EntityProperty extends Nette\Object
 	 * @param  bool $readonly
 	 * @param  string $type
 	 */
-	function __construct(EntityType $reflection, $name, $readonly, $type)
+	function __construct(EntityType $reflection, $name, $readonly, $type, $description)
 	{
 		$this->reflection = $reflection;
 		$this->name = (string) $name;
 		$this->readonly = (bool) $readonly;
 		$this->type = (string) $type;
+		$this->description = (string) $description;
 	}
 
 
@@ -71,6 +75,12 @@ abstract class EntityProperty extends Nette\Object
 	function getType()
 	{
 		return $this->type;
+	}
+
+	/** @return string */
+	function getDescription()
+	{
+		return $this->description;
 	}
 
 

--- a/src/YetORM/Reflection/EntityType.php
+++ b/src/YetORM/Reflection/EntityType.php
@@ -90,6 +90,7 @@ class EntityType extends NClassType
 
 				$name = lcfirst(substr($method->name, 3));
 				$type = $method->getAnnotation('return');
+				$description = $method->getAnnotation('description');
 
 				if (!EntityProperty::isNativeType($type)) {
 					$type = Aliaser::getClass($type, $this);
@@ -99,7 +100,8 @@ class EntityType extends NClassType
 					$this,
 					$name,
 					!$this->hasMethod('set' . ucfirst($name)),
-					$type
+					$type,
+					$description
 				);
 			}
 		}
@@ -173,11 +175,17 @@ class EntityType extends NClassType
 
 							$name = substr($var, 1);
 							$readonly = $ann === 'property-read';
+							$description = null;
 
 							// parse column name
 							$column = $name;
 							if (isset($split[2], $split[3]) && $split[2] === self::PROP_COLUMN_DELIMITER) {
 								$column = $split[3];
+								if (isset($split[4])) {
+									$description = implode(' ', array_slice($split, 4));
+								}
+							} else if (isset($split[2])) {
+								$description = implode(' ', array_slice($split, 2));
 							}
 
 							self::$annProps[$class][$name] = new AnnotationProperty(
@@ -185,6 +193,7 @@ class EntityType extends NClassType
 								$name,
 								$readonly,
 								$type,
+								$description,
 								$column,
 								$nullable
 							);


### PR DESCRIPTION
Sometimes it's useful to access the description of a property (e.g. automatic admin form generation). Since YetORM's EntityProperty reflection already aggregates information about all the properties, it seems to be a good candidate for this.
