### PR TITLE
Composer: define specific dependencies verions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,15 +12,15 @@
 
 	"require": {
 		"php": ">=5.3.0",
-		"nette/utils": "2.*",
-		"nette/database": "2.*",
-		"nette/reflection": "2.*"
+		"nette/utils": "~2.3.0",
+		"nette/database": "~2.3.0",
+		"nette/reflection": "~2.3.0"
 	},
 
 	"require-dev": {
-		"nette/tester": "*",
-		"nette/caching": "*",
-		"nette/robot-loader": "*"
+		"nette/tester": "~1.7.0",
+		"nette/caching": "~2.3.0",
+		"nette/robot-loader": "~2.3.0"
 	},
 
 	"autoload": {


### PR DESCRIPTION
@uestla 

Mozna by nebylo spatne mit definovane konkretni verze. Tezko rict, jestli treba Nette\Database se nebude od verze 2.4 vs 2.3 nejak lisit.

Take jsem moc nezkousel treba verzi 2.0, ale tam uz to nechci menit.