### PR TITLE
Transaction as dependency

### DIFF
--- a/src/YetORM/Repository.php
+++ b/src/YetORM/Repository.php
@@ -41,10 +41,10 @@ abstract class Repository
 
 
 	/** @param  NdbContext $database */
-	public function __construct(NdbContext $database, ?Transaction $transaction = null)
+	public function __construct(NdbContext $database, Transaction $transaction = null)
 	{
 		$this->database = $database;
-		$this->transaction = $transaction ?? new Transaction($database->getConnection());
+		$this->transaction = $transaction ?: new Transaction($database->getConnection());
 	}
 
 

--- a/src/YetORM/Repository.php
+++ b/src/YetORM/Repository.php
@@ -41,10 +41,10 @@ abstract class Repository
 
 
 	/** @param  NdbContext $database */
-	public function __construct(NdbContext $database)
+	public function __construct(NdbContext $database, ?Transaction $transaction = null)
 	{
 		$this->database = $database;
-		$this->transaction = new Transaction($database->getConnection());
+		$this->transaction = $transaction ?? new Transaction($database->getConnection());
 	}
 
 


### PR DESCRIPTION
Z venku nelze použít `NdbContext::beginTransaction`, proto je potřeba vložit Transation jako závislost.